### PR TITLE
Disable SHA-1 on RHEL9

### DIFF
--- a/lasso.spec
+++ b/lasso.spec
@@ -112,6 +112,10 @@ library.
 %build
 ./autogen.sh
 %configure --prefix=%{_prefix} \
+%if 0%{?rhel} > 8
+           --with-min-hash-algo=sha256 \
+           --with-default-sign-algo=rsa-sha256 \
+%endif
 %if !%{with_java}
            --disable-java \
 %endif


### PR DESCRIPTION
RHEL9 version of libxmlsec1 does not handle SHA1 (even in LEGACY openssl mode) which makes lasso fail to validate any signature, even signatures made with SHA256 and above (https://dev.entrouvert.org/issues/74121)

This patch disables SHA1 at compile time on EL9+

